### PR TITLE
node_modules missing in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /lib
 /graph.svg
 /coverage/
+node_modules/
 docs/_site
 stats.json
 /src/parsers/assignment.js=


### PR DESCRIPTION
I find it extra inconvenient to not have this directory ignored.